### PR TITLE
chore: update OS version used for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.15]
+        os: [macos-12.5]
 
     steps:
       - name: Clean up installed software


### PR DESCRIPTION
update OS version used for CI from macOS 10.15 to 12.5